### PR TITLE
fix the version to the closest allowed one

### DIFF
--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -147,7 +147,7 @@ export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
   }
 
   let mostCommonRangeMap = new Map<string, string>();
-  
+
   for (let [depName, specifierMap] of dependencyRangesMapping) {
     const specifierMapEntryArray = Object.entries(specifierMap);
 
@@ -155,12 +155,12 @@ export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
     const maxValue = specifierMapEntryArray.reduce((acc, value) => {
       if(acc[1] === value[1]) {
         // If all dependency ranges occurances are equal, pick the highest.
-        // It's impossible to infer intention of the developer 
+        // It's impossible to infer intention of the developer
         // when all ranges occur an equal amount of times
         const highestRange = highest([acc[0], value[0]]);
         return [ highestRange, acc[1] ];
       }
-      
+
       if(acc[1] > value[1]) {
         return acc;
       }
@@ -185,6 +185,27 @@ export function isArrayEqual(arrA: Array<string>, arrB: Array<string>) {
     }
   }
   return true;
+}
+
+export function getClosestAllowedRange(
+  range: string,
+  allowedVersions: string[]
+) {
+  const major = semver.major(range);
+  const allowedVersionsWithSameMajor = allowedVersions.filter(
+    version => semver.major(version) === major
+  );
+  const possibleRanges =
+    allowedVersionsWithSameMajor.length > 0
+      ? allowedVersionsWithSameMajor
+      : allowedVersions;
+  let closestRange = possibleRanges[0];
+  for (let i = 1; i < possibleRanges.length; i++) {
+    if (semver.gt(possibleRanges[i], closestRange)) {
+      closestRange = possibleRanges[i];
+    }
+  }
+  return closestRange;
 }
 
 function makeCheck<ErrorType>(

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -199,13 +199,7 @@ export function getClosestAllowedRange(
     allowedVersionsWithSameMajor.length > 0
       ? allowedVersionsWithSameMajor
       : allowedVersions;
-  let closestRange = possibleRanges[0];
-  for (let i = 1; i < possibleRanges.length; i++) {
-    if (semver.gt(possibleRanges[i], closestRange)) {
-      closestRange = possibleRanges[i];
-    }
-  }
-  return closestRange;
+  return possibleRanges.sort((a, b) => semver.gt(a, b) ? -1 : 1)[0];
 }
 
 function makeCheck<ErrorType>(


### PR DESCRIPTION
When adding a dependency whose version breaks the external mismatch rule, we clamp it to the closest allowed version instead of most commonly used one.