### PR TITLE
Fix semver range operations

### DIFF
--- a/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH.ts
@@ -263,7 +263,7 @@ it("should not error if the range is included in the allowedDependencyVersions o
 it("should error and fix the version to the closest allowed one when adding an allowed major", () => {
   const options = {
     allowedDependencyVersions: {
-      something: ["^1.0.0", "^2.0.0"]
+      something: ["^1.0.0", "2.0.0"]
     }
   };
 
@@ -281,7 +281,7 @@ it("should error and fix the version to the closest allowed one when adding an a
   // version 2.0.0 is allowed
   let pkg2 = getFakeWS("pkg-2");
   pkg2.packageJson.dependencies = {
-    something: "^2.0.0"
+    something: "2.0.0"
   };
   ws.set("pkg-2", pkg2);
 
@@ -298,11 +298,11 @@ it("should error and fix the version to the closest allowed one when adding an a
     expect.objectContaining({
       dependencyName: "something",
       dependencyRange: "^2.1.0",
-      expectedRange: '^2.0.0'
+      expectedRange: '2.0.0'
     })
   );
   internalMismatch.fix(errors[0], options);
-  expect(pkg2a.packageJson.dependencies.something).toEqual("^2.0.0");
+  expect(pkg2a.packageJson.dependencies.something).toEqual("2.0.0");
 
   // try to add version 1.0.1
   let pkg1b = getFakeWS("pkg-1b");

--- a/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH.ts
@@ -263,32 +263,32 @@ it("should not error if the range is included in the allowedDependencyVersions o
 it("should error and fix the version to the closest allowed one when adding an allowed major", () => {
   const options = {
     allowedDependencyVersions: {
-      something: ["1.0.0", "2.0.0"]
+      something: ["^1.0.0", "^2.0.0"]
     }
   };
 
   let ws = getWS();
 
-  ws.get("pkg-1")!.packageJson.dependencies = { something: "1.0.0" };
+  ws.get("pkg-1")!.packageJson.dependencies = { something: "^1.0.0" };
 
   // version 1.0.0 is the most commonly used one
   let pkg1a = getFakeWS("pkg-1a");
   pkg1a.packageJson.dependencies = {
-    something: "1.0.0"
+    something: "^1.0.0"
   };
   ws.set("pkg-1a", pkg1a);
 
   // version 2.0.0 is allowed
   let pkg2 = getFakeWS("pkg-2");
   pkg2.packageJson.dependencies = {
-    something: "2.0.0"
+    something: "^2.0.0"
   };
   ws.set("pkg-2", pkg2);
 
   // try to add version 2.1.0
   let pkg2a = getFakeWS("pkg-2a");
   pkg2a.packageJson.dependencies = {
-    something: "2.1.0"
+    something: "^2.1.0"
   };
   ws.set("pkg-2a", pkg2a);
 
@@ -297,17 +297,17 @@ it("should error and fix the version to the closest allowed one when adding an a
   expect(errors[0]).toEqual(
     expect.objectContaining({
       dependencyName: "something",
-      dependencyRange: "2.1.0",
-      expectedRange: '2.0.0'
+      dependencyRange: "^2.1.0",
+      expectedRange: '^2.0.0'
     })
   );
   internalMismatch.fix(errors[0], options);
-  expect(pkg2a.packageJson.dependencies.something).toEqual("2.0.0");
+  expect(pkg2a.packageJson.dependencies.something).toEqual("^2.0.0");
 
   // try to add version 1.0.1
   let pkg1b = getFakeWS("pkg-1b");
   pkg1b.packageJson.dependencies = {
-    something: "1.0.1"
+    something: "^1.0.1"
   };
   ws.set("pkg-1b", pkg1b);
 
@@ -316,18 +316,18 @@ it("should error and fix the version to the closest allowed one when adding an a
   expect(errors[0]).toEqual(
     expect.objectContaining({
       dependencyName: "something",
-      dependencyRange: "1.0.1",
-      expectedRange: '1.0.0'
+      dependencyRange: "^1.0.1",
+      expectedRange: '^1.0.0'
     })
   );
   internalMismatch.fix(errors[0], options);
-  expect(pkg1b.packageJson.dependencies.something).toEqual("1.0.0");
+  expect(pkg1b.packageJson.dependencies.something).toEqual("^1.0.0");
 });
 
 it("should error and fix the version to the highest allowed one when adding a newer major", () => {
   const options = {
     allowedDependencyVersions: {
-      something: ["1.0.0", "2.0.0"]
+      something: ["1.0.0", "^2.0.0"]
     }
   };
 
@@ -345,7 +345,7 @@ it("should error and fix the version to the highest allowed one when adding a ne
   // version 2.0.0 is allowed
   let pkg2 = getFakeWS("pkg-2");
   pkg2.packageJson.dependencies = {
-    something: "2.0.0"
+    something: "^2.0.0"
   };
   ws.set("pkg-2", pkg2);
 
@@ -362,9 +362,9 @@ it("should error and fix the version to the highest allowed one when adding a ne
     expect.objectContaining({
       dependencyName: "something",
       dependencyRange: "3.0.0",
-      expectedRange: '2.0.0'
+      expectedRange: '^2.0.0'
     })
   );
   internalMismatch.fix(errors[0], options);
-  expect(pkg3.packageJson.dependencies.something).toEqual("2.0.0");
+  expect(pkg3.packageJson.dependencies.something).toEqual("^2.0.0");
 });

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -1,6 +1,8 @@
 import { Package } from "@manypkg/get-packages";
 import * as semver from "semver";
 import { highest } from "sembear";
+import * as logger from "../logger";
+import { ExitError } from "../errors";
 
 export const NORMAL_DEPENDENCY_TYPES = [
   "dependencies",
@@ -191,15 +193,29 @@ export function getClosestAllowedRange(
   range: string,
   allowedVersions: string[]
 ) {
-  const major = semver.major(range);
+  const major = semver.major(getVersionFromRange(range));
   const allowedVersionsWithSameMajor = allowedVersions.filter(
-    version => semver.major(version) === major
+    version => semver.major(getVersionFromRange(version)) === major
   );
   const possibleRanges =
     allowedVersionsWithSameMajor.length > 0
       ? allowedVersionsWithSameMajor
       : allowedVersions;
-  return possibleRanges.sort((a, b) => semver.gt(a, b) ? -1 : 1)[0];
+  return possibleRanges.sort((a, b) =>
+    semver.gt(getVersionFromRange(a), getVersionFromRange(b)) ? -1 : 1
+  )[0];
+}
+
+function getVersionFromRange(range: string) {
+  if (semver.parse(range)) {
+    return range;
+  }
+  const version = range.substring(1);
+  if (semver.parse(version)) {
+    return version;
+  }
+  logger.error(`Invalid range: ${range}`);
+  throw new ExitError(1);
 }
 
 function makeCheck<ErrorType>(


### PR DESCRIPTION
Most semver APIs don't work on ranges. It slipped through our unit tests because the versions in all test cases don't have a caret.