### PR TITLE
MONO-136 fix semver range check

### DIFF
--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -126,7 +126,7 @@ function weakMemoize<Arg, Ret>(func: (arg: Arg) => Ret): (arg: Arg) => Ret {
 export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
   allPackages: Map<string, Package>
 ) {
-  let dependencyRangesMapping = new Map<string, {[key: string]: number}>();
+  let dependencyRangesMapping = new Map<string, { [key: string]: number }>();
 
   for (let [pkgName, pkg] of allPackages) {
     for (let depType of NORMAL_DEPENDENCY_TYPES) {
@@ -155,21 +155,21 @@ export let getMostCommonRangeMap = weakMemoize(function getMostCommonRanges(
 
     const [first] = specifierMapEntryArray;
     const maxValue = specifierMapEntryArray.reduce((acc, value) => {
-      if(acc[1] === value[1]) {
+      if (acc[1] === value[1]) {
         // If all dependency ranges occurances are equal, pick the highest.
         // It's impossible to infer intention of the developer
         // when all ranges occur an equal amount of times
         const highestRange = highest([acc[0], value[0]]);
-        return [ highestRange, acc[1] ];
+        return [highestRange, acc[1]];
       }
 
-      if(acc[1] > value[1]) {
+      if (acc[1] > value[1]) {
         return acc;
       }
       return value;
     }, first);
 
-    mostCommonRangeMap.set(depName, maxValue[0])
+    mostCommonRangeMap.set(depName, maxValue[0]);
   }
   return mostCommonRangeMap;
 });
@@ -207,12 +207,9 @@ export function getClosestAllowedRange(
 }
 
 function getVersionFromRange(range: string) {
-  if (semver.parse(range)) {
-    return range;
-  }
-  const version = range.substring(1);
-  if (semver.parse(version)) {
-    return version;
+  const minVersion = semver.minVersion(range);
+  if (minVersion) {
+    return minVersion;
   }
   logger.error(`Invalid range: ${range}`);
   throw new ExitError(1);


### PR DESCRIPTION
The previous check only handled version ranges with a single leading character. To fix all other cases, we use the semver.minVersion fn instead to get the minimum version of a range and then return that.

I ran into this when enabling the `INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP` rule in AFE which started triggering violations of the `EXTERNAL_MISMATCH` rule. Manypkg started failing when encountering version ranges like `^16.8.0 || ^17.0.0`.